### PR TITLE
Make the GitOps Operator installation status check more robust

### DIFF
--- a/components/argocd/apps/base/cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/base/cluster-config-app-of-apps.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-config
   source:
     path: patch-me-see-overlays
-    repoURL: https://github.com/redhat-composer-ai/cluster-gitops.git # Update me on fork
+    repoURL: https://github.com/lautou/cluster-gitops.git # Update me on fork
     targetRevision: main
   syncPolicy:
     automated:


### PR DESCRIPTION
Check the GitOps operator installation by monitoring the CSV status instead of minitoring the pods which give a more completed status of the installation progress.