### PR TITLE
Remove the availability check for deployment/kam

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -148,7 +148,6 @@ wait_for_openshift_gitops(){
   echo "Checking status of all openshift-gitops pods"
   GITOPS_RESOURCES=(
     deployment/cluster:condition=Available \
-    deployment/kam:condition=Available \
     statefulset/openshift-gitops-application-controller:jsonpath='{.status.readyReplicas}'=1 \
     deployment/openshift-gitops-applicationset-controller:condition=Available \
     deployment/openshift-gitops-redis:condition=Available \


### PR DESCRIPTION
From OpenShift GitOps 1.15, kam has been removed[1]. So, removing the references to check its availability. 

[1] - https://docs.openshift.com/gitops/1.15/release_notes/gitops-release-notes-1-15.html#removal-of-application-manager-cli-kam_gitops-release-notes